### PR TITLE
upgrade/alot

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v2.2.0
+        uses: dependabot/fetch-metadata@v2.3.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Enable auto-merge for Dependabot PRs

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,7 +39,7 @@ jobs:
     name: Deploy to dev
     needs: [build]
     environment: dev-gcp
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/upgrade/alot'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.1.0
@@ -50,19 +50,19 @@ jobs:
           VARS: .nais/dev.yaml
           VAR: image=${{ needs.build.outputs.image }}
           PRINT_PAYLOAD: true
-
-  deploy-prod:
-    name: Deploy to Production
-    needs: [build, deploy-dev]
-    environment: prod-gcp
-    if: github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4.1.0
-      - uses: nais/deploy/actions/deploy@v2
-        env:
-          CLUSTER: prod-gcp
-          RESOURCE: .nais/nais.yaml
-          VARS: .nais/prod.yaml
-          VAR: image=${{ needs.build.outputs.image }}
-          PRINT_PAYLOAD: true
+#
+#  deploy-prod:
+#    name: Deploy to Production
+#    needs: [build, deploy-dev]
+#    environment: prod-gcp
+#    if: github.ref == 'refs/heads/main'
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v4.1.0
+#      - uses: nais/deploy/actions/deploy@v2
+#        env:
+#          CLUSTER: prod-gcp
+#          RESOURCE: .nais/nais.yaml
+#          VARS: .nais/prod.yaml
+#          VAR: image=${{ needs.build.outputs.image }}
+#          PRINT_PAYLOAD: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,7 +39,7 @@ jobs:
     name: Deploy to dev
     needs: [build]
     environment: dev-gcp
-    if: github.ref == 'refs/heads/upgrade/alot'
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.1.0
@@ -50,19 +50,19 @@ jobs:
           VARS: .nais/dev.yaml
           VAR: image=${{ needs.build.outputs.image }}
           PRINT_PAYLOAD: true
-#
-#  deploy-prod:
-#    name: Deploy to Production
-#    needs: [build, deploy-dev]
-#    environment: prod-gcp
-#    if: github.ref == 'refs/heads/main'
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v4.1.0
-#      - uses: nais/deploy/actions/deploy@v2
-#        env:
-#          CLUSTER: prod-gcp
-#          RESOURCE: .nais/nais.yaml
-#          VARS: .nais/prod.yaml
-#          VAR: image=${{ needs.build.outputs.image }}
-#          PRINT_PAYLOAD: true
+
+  deploy-prod:
+    name: Deploy to Production
+    needs: [build, deploy-dev]
+    environment: prod-gcp
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.1.0
+      - uses: nais/deploy/actions/deploy@v2
+        env:
+          CLUSTER: prod-gcp
+          RESOURCE: .nais/nais.yaml
+          VARS: .nais/prod.yaml
+          VAR: image=${{ needs.build.outputs.image }}
+          PRINT_PAYLOAD: true

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ target
 .idea/
 out/
 
+# Other
+.kotlin/
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,7 @@
-FROM ghcr.io/navikt/baseimages/temurin:21
+FROM gcr.io/distroless/java21
 
-COPY build/libs/*-all.jar app.jar
+ENV LANG='nb_NO.UTF-8' LANGUAGE='nb_NO:nb' LC_ALL='nb:NO.UTF-8' TZ="Europe/Oslo"
+
+COPY build/libs/dp-mellomlagring-all.jar /app.jar
+
+ENTRYPOINT ["java", "-jar", "/app.jar"]

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -72,7 +72,7 @@ dependencies {
     implementation("no.nav.dagpenger:image-utils:2024.10.24-13.47.d2fb89767416")
     implementation(libs.dp.biblioteker.ktor.klient.metrics)
 
-    implementation("io.micrometer:micrometer-registry-prometheus:1.13.6")
+    implementation("io.micrometer:micrometer-registry-prometheus:1.14.1")
     implementation(libs.jackson.datatype.jsr310)
     implementation("io.ktor:ktor-server-swagger:${libs.versions.ktor.get()}")
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -69,7 +69,7 @@ dependencies {
     implementation(libs.bundles.ktor.server)
     implementation(libs.ktor.server.cio)
     implementation(libs.ktor.server.metrics.micrometer)
-    implementation("no.nav.dagpenger:image-utils:2024.09.20-13.31.40516c678fde")
+    implementation("no.nav.dagpenger:image-utils:2024.10.24-13.47.d2fb89767416")
     implementation(libs.dp.biblioteker.ktor.klient.metrics)
 
     implementation("io.micrometer:micrometer-registry-prometheus:1.13.6")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -76,7 +76,7 @@ dependencies {
     implementation(libs.jackson.datatype.jsr310)
     implementation("io.ktor:ktor-server-swagger:${libs.versions.ktor.get()}")
 
-    implementation("com.google.crypto.tink:tink:1.15.0")
+    implementation("com.google.crypto.tink:tink:1.16.0")
     implementation("com.google.crypto.tink:tink-gcpkms:1.10.0")
     implementation("de.slub-dresden:urnlib:2.0.1")
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -70,7 +70,7 @@ dependencies {
     implementation(libs.ktor.server.cio)
     implementation(libs.ktor.server.metrics.micrometer)
     implementation("no.nav.dagpenger:image-utils:2024.12.10-13.49.efde9da2574c")
-    implementation(libs.dp.biblioteker.ktor.klient.metrics)
+    implementation("no.nav.dagpenger:ktor-client-metrics:2025.02.13-18.02.052b7c34baab")
 
     implementation("io.micrometer:micrometer-registry-prometheus:1.14.4")
     implementation(libs.jackson.datatype.jsr310)
@@ -107,7 +107,6 @@ dependencies {
 
     testImplementation("org.skyscreamer:jsonassert:1.5.3")
 
-    // For E2E
-    testImplementation("io.kubernetes:client-java:23.0.0-legacy")
-    testImplementation(libs.dp.biblioteker.oauth2.klient)
+    testImplementation("io.kubernetes:client-java:23.0.0")
+    testImplementation("no.nav.dagpenger:oauth2-klient:2025.02.13-18.02.052b7c34baab")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -72,7 +72,7 @@ dependencies {
     implementation("no.nav.dagpenger:image-utils:2024.10.24-13.47.d2fb89767416")
     implementation(libs.dp.biblioteker.ktor.klient.metrics)
 
-    implementation("io.micrometer:micrometer-registry-prometheus:1.14.3")
+    implementation("io.micrometer:micrometer-registry-prometheus:1.14.4")
     implementation(libs.jackson.datatype.jsr310)
     implementation("io.ktor:ktor-server-swagger:${libs.versions.ktor.get()}")
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -108,6 +108,6 @@ dependencies {
     testImplementation("org.skyscreamer:jsonassert:1.5.3")
 
     // For E2E
-    testImplementation("io.kubernetes:client-java:21.0.2")
+    testImplementation("io.kubernetes:client-java:23.0.0-legacy")
     testImplementation(libs.dp.biblioteker.oauth2.klient)
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     application
     alias(libs.plugins.kotlin)
     alias(libs.plugins.spotless)
-    id("com.gradleup.shadow") version "8.3.5"
+    id("com.gradleup.shadow") version "8.3.6"
 }
 
 repositories {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -82,7 +82,7 @@ dependencies {
 
     runtimeOnly(libs.logback.core)
     runtimeOnly(libs.logback.classic)
-    runtimeOnly("net.logstash.logback:logstash-logback-encoder:7.4") {
+    runtimeOnly("net.logstash.logback:logstash-logback-encoder:8.0") {
         exclude("com.fasterxml.jackson.core")
     }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -72,7 +72,7 @@ dependencies {
     implementation("no.nav.dagpenger:image-utils:2024.10.24-13.47.d2fb89767416")
     implementation(libs.dp.biblioteker.ktor.klient.metrics)
 
-    implementation("io.micrometer:micrometer-registry-prometheus:1.14.1")
+    implementation("io.micrometer:micrometer-registry-prometheus:1.14.3")
     implementation(libs.jackson.datatype.jsr310)
     implementation("io.ktor:ktor-server-swagger:${libs.versions.ktor.get()}")
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -69,7 +69,7 @@ dependencies {
     implementation(libs.bundles.ktor.server)
     implementation(libs.ktor.server.cio)
     implementation(libs.ktor.server.metrics.micrometer)
-    implementation("no.nav.dagpenger:image-utils:2024.10.24-13.47.d2fb89767416")
+    implementation("no.nav.dagpenger:image-utils:2024.12.10-13.49.efde9da2574c")
     implementation(libs.dp.biblioteker.ktor.klient.metrics)
 
     implementation("io.micrometer:micrometer-registry-prometheus:1.14.4")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -10,7 +10,7 @@ dependencyResolutionManagement {
     }
     versionCatalogs {
         create("libs") {
-            from("no.nav.dagpenger:dp-version-catalog:20250224.132.e46261")
+            from("no.nav.dagpenger:dp-version-catalog:20250227.136.d15eef")
         }
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -10,7 +10,7 @@ dependencyResolutionManagement {
     }
     versionCatalogs {
         create("libs") {
-            from("no.nav.dagpenger:dp-version-catalog:20250113.124.cdd1f7")
+            from("no.nav.dagpenger:dp-version-catalog:20250116.126.fed812")
         }
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -10,7 +10,7 @@ dependencyResolutionManagement {
     }
     versionCatalogs {
         create("libs") {
-            from("no.nav.dagpenger:dp-version-catalog:20241202.107.edb8bd")
+            from("no.nav.dagpenger:dp-version-catalog:20241204.110.0da3e7")
         }
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -10,7 +10,7 @@ dependencyResolutionManagement {
     }
     versionCatalogs {
         create("libs") {
-            from("no.nav.dagpenger:dp-version-catalog:20241022.94.4a3bcc")
+            from("no.nav.dagpenger:dp-version-catalog:20241202.107.edb8bd")
         }
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -10,7 +10,7 @@ dependencyResolutionManagement {
     }
     versionCatalogs {
         create("libs") {
-            from("no.nav.dagpenger:dp-version-catalog:20250108.121.607710")
+            from("no.nav.dagpenger:dp-version-catalog:20250113.124.cdd1f7")
         }
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -10,7 +10,7 @@ dependencyResolutionManagement {
     }
     versionCatalogs {
         create("libs") {
-            from("no.nav.dagpenger:dp-version-catalog:20241219.117.d9df42")
+            from("no.nav.dagpenger:dp-version-catalog:20250108.121.607710")
         }
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -10,7 +10,7 @@ dependencyResolutionManagement {
     }
     versionCatalogs {
         create("libs") {
-            from("no.nav.dagpenger:dp-version-catalog:20250127.127.889f17")
+            from("no.nav.dagpenger:dp-version-catalog:20250224.132.e46261")
         }
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -10,7 +10,7 @@ dependencyResolutionManagement {
     }
     versionCatalogs {
         create("libs") {
-            from("no.nav.dagpenger:dp-version-catalog:20250303.140.82ddc5")
+            from("no.nav.dagpenger:dp-version-catalog:20250306.142.3d919e")
         }
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -10,7 +10,7 @@ dependencyResolutionManagement {
     }
     versionCatalogs {
         create("libs") {
-            from("no.nav.dagpenger:dp-version-catalog:20250227.136.d15eef")
+            from("no.nav.dagpenger:dp-version-catalog:20250303.140.82ddc5")
         }
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -10,7 +10,7 @@ dependencyResolutionManagement {
     }
     versionCatalogs {
         create("libs") {
-            from("no.nav.dagpenger:dp-version-catalog:20241211.112.8baa0c")
+            from("no.nav.dagpenger:dp-version-catalog:20241219.117.d9df42")
         }
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -10,7 +10,7 @@ dependencyResolutionManagement {
     }
     versionCatalogs {
         create("libs") {
-            from("no.nav.dagpenger:dp-version-catalog:20250116.126.fed812")
+            from("no.nav.dagpenger:dp-version-catalog:20250127.127.889f17")
         }
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -10,7 +10,7 @@ dependencyResolutionManagement {
     }
     versionCatalogs {
         create("libs") {
-            from("no.nav.dagpenger:dp-version-catalog:20241204.110.0da3e7")
+            from("no.nav.dagpenger:dp-version-catalog:20241211.112.8baa0c")
         }
     }
 }

--- a/src/main/kotlin/no/nav/dagpenger/mellomlagring/App.kt
+++ b/src/main/kotlin/no/nav/dagpenger/mellomlagring/App.kt
@@ -13,7 +13,7 @@ import io.ktor.server.engine.embeddedServer
 import io.ktor.server.logging.toLogString
 import io.ktor.server.plugins.callid.CallId
 import io.ktor.server.plugins.callid.callIdMdc
-import io.ktor.server.plugins.callloging.CallLogging
+import io.ktor.server.plugins.calllogging.CallLogging
 import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.server.plugins.statuspages.StatusPages
 import io.ktor.server.plugins.swagger.swaggerUI
@@ -118,7 +118,10 @@ internal fun Application.ktorFeatures() {
                             title = "Fil er ugyldig",
                             status = 400,
                             detail = cause.message,
-                            errorType = cause.feilMeldinger.keys.first().name,
+                            errorType =
+                                cause.feilMeldinger.keys
+                                    .first()
+                                    .name,
                         ),
                     )
                 }

--- a/src/main/kotlin/no/nav/dagpenger/mellomlagring/Config.kt
+++ b/src/main/kotlin/no/nav/dagpenger/mellomlagring/Config.kt
@@ -55,7 +55,10 @@ internal object Config {
             ConfigurationProperties.systemProperties() overriding EnvironmentVariables() overriding defaultProperties
 
     object AzureAd {
-        internal data class PreAuthorizedApp(val name: String, val clientId: String) {
+        internal data class PreAuthorizedApp(
+            val name: String,
+            val clientId: String,
+        ) {
             companion object {
                 fun from(data: String): List<PreAuthorizedApp> = jacksonObjectMapper().readValue(data)
             }
@@ -124,12 +127,14 @@ internal object Config {
     internal fun localStorage(
         storageUrl: String,
         createBucket: Boolean,
-    ) = StorageOptions.newBuilder()
+    ) = StorageOptions
+        .newBuilder()
         .setCredentials(NoCredentials.getInstance())
         .setHost(storageUrl) // From docker-compose
         .setProjectId("dagpenger")
         .build()
-        .service.also { it ->
+        .service
+        .also { it ->
             if (createBucket && it.get(bucketName) == null) {
                 it.create(BucketInfo.of(bucketName))
             }

--- a/src/main/kotlin/no/nav/dagpenger/mellomlagring/auth/Auth.kt
+++ b/src/main/kotlin/no/nav/dagpenger/mellomlagring/auth/Auth.kt
@@ -58,8 +58,8 @@ private data class OpenIDConfiguration(
     val issuer: String,
 )
 
-private fun cachedJwkProvider(jwksUri: String): JwkProvider {
-    return JwkProviderBuilder(URL(jwksUri))
+private fun cachedJwkProvider(jwksUri: String): JwkProvider =
+    JwkProviderBuilder(URL(jwksUri))
         .cached(10, 24, TimeUnit.HOURS) // cache up to 10 JWKs for 24 hours
         .rateLimited(
             10,
@@ -67,7 +67,6 @@ private fun cachedJwkProvider(jwksUri: String): JwkProvider {
             TimeUnit.MINUTES,
         ) // if not cached, only allow max 10 different keys per minute to be fetched from external provider
         .build()
-}
 
 private val httpClient =
     HttpClient {

--- a/src/main/kotlin/no/nav/dagpenger/mellomlagring/av/AntiVirus.kt
+++ b/src/main/kotlin/no/nav/dagpenger/mellomlagring/av/AntiVirus.kt
@@ -35,16 +35,14 @@ internal data class ScanResult(
     @JsonProperty("Result")
     val result: String,
 ) {
-    fun infisert(): Boolean {
-        return result.uppercase() != "OK"
-    }
+    fun infisert(): Boolean = result.uppercase() != "OK"
 }
 
 internal fun clamAv(
     engine: HttpClientEngine = CIO.create(),
     registry: PrometheusRegistry = PrometheusRegistry.defaultRegistry,
-): AntiVirus {
-    return object : AntiVirus {
+): AntiVirus =
+    object : AntiVirus {
         private val httpClient =
             HttpClient(engine) {
                 install(ContentNegotiation) {
@@ -77,12 +75,13 @@ internal fun clamAv(
         override suspend fun infisert(
             filnavn: String,
             filinnhold: ByteArray,
-        ): Boolean {
-            return runCatching<List<ScanResult>> {
-                httpClient.put {
-                    url("http://clamav.nais-system.svc.cluster.local/scan")
-                    setBody(ByteArrayInputStream(filinnhold))
-                }.body()
+        ): Boolean =
+            runCatching<List<ScanResult>> {
+                httpClient
+                    .put {
+                        url("http://clamav.nais-system.svc.cluster.local/scan")
+                        setBody(ByteArrayInputStream(filinnhold))
+                    }.body()
             }.fold(
                 onSuccess = {
                     require(it.isNotEmpty()) { "Skal ikke få tom liste fra clamv.  " }
@@ -96,6 +95,4 @@ internal fun clamAv(
                     throw t
                 },
             ).any { it.infisert() }
-        }
     }
-}

--- a/src/main/kotlin/no/nav/dagpenger/mellomlagring/lagring/S3Store.kt
+++ b/src/main/kotlin/no/nav/dagpenger/mellomlagring/lagring/S3Store.kt
@@ -25,68 +25,72 @@ internal class S3Store(
         }
     }
 
-    override fun hent(storageKey: StorageKey): Result<Klump?> {
-        return kotlin.runCatching {
-            gcpStorage.get(BlobId.of(bucketName, storageKey))?.let { blob ->
-                Klump(
-                    innhold = blob.getContent(),
-                    klumpInfo = KlumpInfo.fromBlob(blob),
-                )
+    override fun hent(storageKey: StorageKey): Result<Klump?> =
+        kotlin
+            .runCatching {
+                gcpStorage.get(BlobId.of(bucketName, storageKey))?.let { blob ->
+                    Klump(
+                        innhold = blob.getContent(),
+                        klumpInfo = KlumpInfo.fromBlob(blob),
+                    )
+                }
+            }.onFailure {
+                logger.error(it) { "Feilet å hente fil: $storageKey" }
             }
-        }.onFailure {
-            logger.error(it) { "Feilet å hente fil: $storageKey" }
-        }
-    }
 
     override fun lagre(klump: Klump): Result<Int> {
         val blobInfo =
-            BlobInfo.newBuilder(BlobId.of(bucketName, klump.klumpInfo.objektNavn))
+            BlobInfo
+                .newBuilder(BlobId.of(bucketName, klump.klumpInfo.objektNavn))
                 .setContentType(klump.klumpInfo.filContentType)
                 .setMetadata(klump.klumpInfo.toMetadata())
                 .build() // todo contentType?
 
-        return kotlin.runCatching {
-            gcpStorage.writer(blobInfo).use {
-                it.write(ByteBuffer.wrap(klump.innhold, 0, klump.innhold.size))
+        return kotlin
+            .runCatching {
+                gcpStorage.writer(blobInfo).use {
+                    it.write(ByteBuffer.wrap(klump.innhold, 0, klump.innhold.size))
+                }
+            }.onFailure { e ->
+                logger.warn(e) { "Feilet med å lagre fil med id: ${blobInfo.blobId.name}" }
+            }.onSuccess {
+                logger.info("Lagret fil med blobid: ${blobInfo.blobId.name} og bytes: $it")
             }
-        }.onFailure { e ->
-            logger.warn(e) { "Feilet med å lagre fil med id: ${blobInfo.blobId.name}" }
-        }.onSuccess {
-            logger.info("Lagret fil med blobid: ${blobInfo.blobId.name} og bytes: $it")
-        }
     }
 
-    override fun slett(storageKey: StorageKey): Result<Boolean> {
-        return kotlin.runCatching {
-            gcpStorage.get(BlobId.of(bucketName, storageKey))?.delete(BlobSourceOption.generationMatch()) ?: false
-        }.onFailure { e ->
-            logger.warn("Feilet å slette fil med id: $storageKey", e)
-        }.onSuccess {
-            logger.info("Fil $storageKey slettet med resultat: $it ")
-        }
-    }
+    override fun slett(storageKey: StorageKey): Result<Boolean> =
+        kotlin
+            .runCatching {
+                gcpStorage.get(BlobId.of(bucketName, storageKey))?.delete(BlobSourceOption.generationMatch()) ?: false
+            }.onFailure { e ->
+                logger.warn("Feilet å slette fil med id: $storageKey", e)
+            }.onSuccess {
+                logger.info("Fil $storageKey slettet med resultat: $it ")
+            }
 
-    override fun hentKlumpInfo(storageKey: StorageKey): Result<KlumpInfo?> {
-        return kotlin.runCatching {
-            gcpStorage.get(BlobId.of(bucketName, storageKey))
-                ?.let { KlumpInfo.fromBlob(blob = it) }
-        }.onSuccess {
-            logger.debug { "Listet klumpinfo for fil: $storageKey" }
-        }.onFailure {
-            logger.warn(it) { "Feilet å liste klumpinfo for fil: $storageKey " }
-        }
-    }
+    override fun hentKlumpInfo(storageKey: StorageKey): Result<KlumpInfo?> =
+        kotlin
+            .runCatching {
+                gcpStorage
+                    .get(BlobId.of(bucketName, storageKey))
+                    ?.let { KlumpInfo.fromBlob(blob = it) }
+            }.onSuccess {
+                logger.debug { "Listet klumpinfo for fil: $storageKey" }
+            }.onFailure {
+                logger.warn(it) { "Feilet å liste klumpinfo for fil: $storageKey " }
+            }
 
-    override fun listKlumpInfo(keyPrefix: StorageKey): Result<List<KlumpInfo>> {
-        return kotlin.runCatching {
-            gcpStorage.list(bucketName, Storage.BlobListOption.prefix(keyPrefix))
-                ?.values
-                ?.map(KlumpInfo.Companion::fromBlob)
-                ?: emptyList()
-        }.onSuccess {
-            logger.debug { "Listet klumpinfo for path: $keyPrefix" }
-        }.onFailure {
-            logger.warn(it) { "Feilet å liste klumpinfo for path: $keyPrefix " }
-        }
-    }
+    override fun listKlumpInfo(keyPrefix: StorageKey): Result<List<KlumpInfo>> =
+        kotlin
+            .runCatching {
+                gcpStorage
+                    .list(bucketName, Storage.BlobListOption.prefix(keyPrefix))
+                    ?.values
+                    ?.map(KlumpInfo.Companion::fromBlob)
+                    ?: emptyList()
+            }.onSuccess {
+                logger.debug { "Listet klumpinfo for path: $keyPrefix" }
+            }.onFailure {
+                logger.warn(it) { "Feilet å liste klumpinfo for path: $keyPrefix " }
+            }
 }

--- a/src/main/kotlin/no/nav/dagpenger/mellomlagring/lagring/Store.kt
+++ b/src/main/kotlin/no/nav/dagpenger/mellomlagring/lagring/Store.kt
@@ -61,4 +61,6 @@ internal class Klump(
 
 internal typealias StorageKey = String
 
-internal class StoreException(msg: String) : Throwable(msg)
+internal class StoreException(
+    msg: String,
+) : Throwable(msg)

--- a/src/main/kotlin/no/nav/dagpenger/mellomlagring/pdf/BundleMediator.kt
+++ b/src/main/kotlin/no/nav/dagpenger/mellomlagring/pdf/BundleMediator.kt
@@ -12,46 +12,49 @@ import no.nav.dagpenger.mellomlagring.vedlegg.VedleggUrn
 private val sikkerlogg = KotlinLogging.logger("tjenestekall")
 private val logger = KotlinLogging.logger { }
 
-internal class BundleMediator(private val mediator: Mediator) {
+internal class BundleMediator(
+    private val mediator: Mediator,
+) {
     suspend fun bundle(
         request: BundleRequest,
         eier: String,
     ): KlumpInfo {
         Metrics.bundlerRequestCounter.inc()
-        return kotlin.runCatching {
-            val pdf: ByteArray =
-                request.filer
-                    .map { hent(VedleggUrn(it.namespaceSpecificString().toString()), eier) }
-                    .map { it.getOrThrow().innhold }
-                    .map { it.tilPdf() }
-                    .reduce(ImageProcessor::mergePdf)
+        return kotlin
+            .runCatching {
+                val pdf: ByteArray =
+                    request.filer
+                        .map { hent(VedleggUrn(it.namespaceSpecificString().toString()), eier) }
+                        .map { it.getOrThrow().innhold }
+                        .map { it.tilPdf() }
+                        .reduce(ImageProcessor::mergePdf)
 
-            mediator.lagre(
-                soknadsId = request.soknadId,
-                filnavn = request.bundleNavn,
-                filinnhold = pdf,
-                eier = eier,
-                filContentType = "application/pdf",
-            )
-        }.onSuccess {
-            logger.info { "Bundlet ${request.filer} -> ${it.objektNavn}" }
-        }.onFailure {
-            logger.warn(it) { "Feilet bundling av ${request.filer} med bundlenavn ${request.bundleNavn}. Se sikker logg for eier" }
-            sikkerlogg.error { "Feilet bundling av ${request.filer} med bundlenavn ${request.bundleNavn} og eier $eier" }
-            Metrics.bundlerErrorTypesCounter.labelValues(it.javaClass.simpleName).inc()
-        }.getOrThrow()
+                mediator.lagre(
+                    soknadsId = request.soknadId,
+                    filnavn = request.bundleNavn,
+                    filinnhold = pdf,
+                    eier = eier,
+                    filContentType = "application/pdf",
+                )
+            }.onSuccess {
+                logger.info { "Bundlet ${request.filer} -> ${it.objektNavn}" }
+            }.onFailure {
+                logger.warn(it) { "Feilet bundling av ${request.filer} med bundlenavn ${request.bundleNavn}. Se sikker logg for eier" }
+                sikkerlogg.error { "Feilet bundling av ${request.filer} med bundlenavn ${request.bundleNavn} og eier $eier" }
+                Metrics.bundlerErrorTypesCounter.labelValues(it.javaClass.simpleName).inc()
+            }.getOrThrow()
     }
 
     private suspend fun hent(
         urn: VedleggUrn,
         eier: String,
-    ): Result<Klump> {
-        return kotlin.runCatching {
-            mediator.hent(urn, eier)
-        }.mapCatching {
-            it ?: throw NotFoundException("Fant ikke $urn")
-        }.onFailure {
-            sikkerlogg.error { "Henting av vedlegg $urn feilet for eier $eier" }
-        }
-    }
+    ): Result<Klump> =
+        kotlin
+            .runCatching {
+                mediator.hent(urn, eier)
+            }.mapCatching {
+                it ?: throw NotFoundException("Fant ikke $urn")
+            }.onFailure {
+                sikkerlogg.error { "Henting av vedlegg $urn feilet for eier $eier" }
+            }
 }

--- a/src/main/kotlin/no/nav/dagpenger/mellomlagring/pdf/BundleRequestDeserializer.kt
+++ b/src/main/kotlin/no/nav/dagpenger/mellomlagring/pdf/BundleRequestDeserializer.kt
@@ -13,26 +13,28 @@ internal object BundleRequestDeserializer : JsonDeserializer<BundleRequest>() {
     override fun deserialize(
         p: JsonParser,
         ctxt: DeserializationContext,
-    ): BundleRequest {
-        return kotlin.runCatching {
-            p.readValueAsTree<JsonNode>().let { node ->
-                BundleRequest(node.soknadId(), node.bundleNavn(), node.urns())
-            }
-        }.fold(
-            onSuccess = { it },
-            onFailure = { t ->
-                sikkerlogg.error("Kunne ikke deserialisere bundlerequest: " + t.cause)
-                throw IllegalArgumentException(t)
-            },
-        )
-    }
+    ): BundleRequest =
+        kotlin
+            .runCatching {
+                p.readValueAsTree<JsonNode>().let { node ->
+                    BundleRequest(node.soknadId(), node.bundleNavn(), node.urns())
+                }
+            }.fold(
+                onSuccess = { it },
+                onFailure = { t ->
+                    sikkerlogg.error("Kunne ikke deserialisere bundlerequest: " + t.cause)
+                    throw IllegalArgumentException(t)
+                },
+            )
 
     private fun JsonNode.soknadId() = this["soknadId"].asText()
 
     private fun JsonNode.bundleNavn() = this.get("bundleNavn").asText()
 
     private fun JsonNode.urns(): Set<URN> =
-        this.get("filer").map { urnNode ->
-            URN.rfc8141().parse(urnNode.get("urn").asText())
-        }.toSet()
+        this
+            .get("filer")
+            .map { urnNode ->
+                URN.rfc8141().parse(urnNode.get("urn").asText())
+            }.toSet()
 }

--- a/src/main/kotlin/no/nav/dagpenger/mellomlagring/pdf/ImageProcessor.kt
+++ b/src/main/kotlin/no/nav/dagpenger/mellomlagring/pdf/ImageProcessor.kt
@@ -15,17 +15,16 @@ internal object ImageProcessor {
     fun mergePdf(
         accumulator: ByteArray,
         currentValue: ByteArray,
-    ): ByteArray {
-        return PDFDocument.merge(listOf(accumulator, currentValue)).use { pdf ->
+    ): ByteArray =
+        PDFDocument.merge(listOf(accumulator, currentValue)).use { pdf ->
             ByteArrayOutputStream().use { os ->
                 pdf.save(BufferedOutputStream(os))
                 os.toByteArray()
             }
         }
-    }
 
-    fun ByteArray.tilPdf(): ByteArray {
-        return when {
+    fun ByteArray.tilPdf(): ByteArray =
+        when {
             this.isJpeg() -> {
                 scaleImage(this, "jpeg")
             }
@@ -39,13 +38,12 @@ internal object ImageProcessor {
                 throw IllegalArgumentException("ukjent format")
             }
         }
-    }
 
     private fun scaleImage(
         it: ByteArray,
         format: String,
-    ): ByteArray {
-        return ByteArrayOutputStream().use { os ->
+    ): ByteArray =
+        ByteArrayOutputStream().use { os ->
             ImageIO.write(
                 ImageScaler.scale(
                     it,
@@ -57,5 +55,4 @@ internal object ImageProcessor {
             )
             ImageConverter.toPDF(os.toByteArray())
         }
-    }
 }

--- a/src/main/kotlin/no/nav/dagpenger/mellomlagring/vedlegg/Validering.kt
+++ b/src/main/kotlin/no/nav/dagpenger/mellomlagring/vedlegg/Validering.kt
@@ -8,16 +8,17 @@ import no.nav.dagpenger.pdf.InvalidPDFDocument
 import no.nav.dagpenger.pdf.PDFDocument
 import no.nav.dagpenger.pdf.ValidPDFDocument
 
-internal class AntiVirusValidering(private val antiVirus: AntiVirus) : Mediator.FilValidering {
+internal class AntiVirusValidering(
+    private val antiVirus: AntiVirus,
+) : Mediator.FilValidering {
     override suspend fun valider(
         filnavn: String,
         filinnhold: ByteArray,
-    ): FilValideringResultat {
-        return when (antiVirus.infisert(filnavn, filinnhold)) {
+    ): FilValideringResultat =
+        when (antiVirus.infisert(filnavn, filinnhold)) {
             true -> FilValideringResultat.Ugyldig(filnavn, "Fil har virus", FeilType.FILE_VIRUS)
             else -> FilValideringResultat.Gyldig(filnavn)
         }
-    }
 }
 
 internal object FiltypeValidering : Mediator.FilValidering {

--- a/src/main/kotlin/no/nav/dagpenger/mellomlagring/vedlegg/VedleggApi.kt
+++ b/src/main/kotlin/no/nav/dagpenger/mellomlagring/vedlegg/VedleggApi.kt
@@ -7,7 +7,6 @@ import io.ktor.http.content.PartData
 import io.ktor.http.content.forEachPart
 import io.ktor.server.application.Application
 import io.ktor.server.application.ApplicationCall
-import io.ktor.server.application.call
 import io.ktor.server.auth.authenticate
 import io.ktor.server.request.receiveMultipart
 import io.ktor.server.response.respond
@@ -19,11 +18,11 @@ import io.ktor.server.routing.post
 import io.ktor.server.routing.route
 import io.ktor.server.routing.routing
 import io.ktor.utils.io.toByteArray
-import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
 import mu.KotlinLogging
 import no.nav.dagpenger.mellomlagring.Config
@@ -141,39 +140,41 @@ internal class FileUploadHandler(
         eier: String,
     ): List<KlumpInfo> =
         coroutineScope {
-            val jobs = mutableListOf<Deferred<KlumpInfo>>()
+            val files = mutableListOf<Pair<String, ByteArray>>()
             multiPartData.forEachPart { part ->
                 when (part) {
                     is PartData.FileItem -> {
                         val fileName = part.originalFileName ?: throw IllegalArgumentException("Filnavn mangler")
-
-                        jobs.add(
-                            async(Dispatchers.IO) {
-                                val bytes = part.provider().toByteArray()
-                                mediator.lagre(
-                                    soknadsId,
-                                    fileName,
-                                    bytes,
-                                    part.contentType?.toString() ?: "application/octet-stream",
-                                    eier,
-                                )
-                            },
-                        )
+                        files.add(fileName to part.provider().toByteArray())
                     }
+
                     is PartData.BinaryItem ->
                         part.dispose().also {
                             logger.warn { "binary item not supported" }
                         }
+
                     is PartData.FormItem ->
                         part.dispose().also {
                             logger.warn { "form item not supported" }
                         }
+
                     is PartData.BinaryChannelItem ->
                         part.dispose().also {
                             logger.warn { "BinaryChannel item not supported" }
                         }
                 }
             }
-            jobs.awaitAll()
+            files
+                .map { file ->
+                    async(Dispatchers.IO) {
+                        mediator.lagre(
+                            soknadsId,
+                            file.first,
+                            file.second,
+                            "application/octet-stream",
+                            eier,
+                        )
+                    }
+                }.awaitAll()
         }
 }

--- a/src/main/kotlin/no/nav/dagpenger/mellomlagring/vedlegg/VedleggApi.kt
+++ b/src/main/kotlin/no/nav/dagpenger/mellomlagring/vedlegg/VedleggApi.kt
@@ -5,7 +5,6 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.content.MultiPartData
 import io.ktor.http.content.PartData
 import io.ktor.http.content.forEachPart
-import io.ktor.http.content.streamProvider
 import io.ktor.server.application.Application
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.application.call
@@ -19,6 +18,7 @@ import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import io.ktor.server.routing.route
 import io.ktor.server.routing.routing
+import io.ktor.utils.io.toByteArray
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
@@ -149,7 +149,7 @@ internal class FileUploadHandler(
 
                         jobs.add(
                             async(Dispatchers.IO) {
-                                val bytes = part.streamProvider().readBytes()
+                                val bytes = part.provider().toByteArray()
                                 mediator.lagre(
                                     soknadsId,
                                     fileName,

--- a/src/main/kotlin/no/nav/dagpenger/mellomlagring/vedlegg/VedleggUrn.kt
+++ b/src/main/kotlin/no/nav/dagpenger/mellomlagring/vedlegg/VedleggUrn.kt
@@ -11,14 +11,13 @@ internal class VedleggUrn(
     }
 
     val urn: String =
-        kotlin.runCatching { URN.rfc8141().parse("urn:$VEDLEGG_NAMESPACE_IDENTIFIER:$nss") }
+        kotlin
+            .runCatching { URN.rfc8141().parse("urn:$VEDLEGG_NAMESPACE_IDENTIFIER:$nss") }
             .map { it.toString() }
             .onFailure { t -> throw IllegalArgumentException(t) }
             .getOrThrow()
 
-    override fun equals(other: Any?): Boolean {
-        return other != null && other is VedleggUrn && this.urn == other.urn
-    }
+    override fun equals(other: Any?): Boolean = other != null && other is VedleggUrn && this.urn == other.urn
 
     override fun hashCode() = urn.hashCode()
 

--- a/src/test/kotlin/no/nav/dagpenger/mellomlagring/E2E.kt
+++ b/src/test/kotlin/no/nav/dagpenger/mellomlagring/E2E.kt
@@ -166,9 +166,9 @@ internal class E2E {
     // må erstattes om en skal sende inn filer på nytt
     private val soknadId = UUID.randomUUID().toString()
 
-    // selvbetjeningstoken er tidsbegrenset, så det må erstattes med jevne mellomrom,
-    // logg inn på søknaden i dev med eier 51818700273 og kopier selvbetjening-token fra devtools ->Appilcation->Storage
-    private val selvbetjeningsIdToken = ""
+    // oboToken er tidsbegrenset, så det må erstattes med jevne mellomrom,
+    // Hent fra https://tokenx-token-generator.intern.dev.nav.no/api/obo?aud=dev-gcp:teamdagpenger:dp-mellomlagring
+    private val oboToken = ""
 
 
     @Test
@@ -222,11 +222,6 @@ internal class E2E {
                 }
             }
         runBlocking {
-            val oboToken =
-                getOboToken(
-                    "dp-soknadsdialog",
-                    selvbetjeningsIdToken,
-                )
             // Send filer til mellomlagring
             val responseList =
                 measure("Tid brukt på å sender opp filer") {
@@ -276,11 +271,6 @@ internal class E2E {
     fun e2e() {
         runBlocking {
             log("Running test with id: $soknadId and eier $eier")
-            val oboToken =
-                getOboToken(
-                    "dp-soknadsdialog",
-                    selvbetjeningsIdToken,
-                )
 
             // Send ugyldig filer
             log("sender ugyldige filer")

--- a/src/test/kotlin/no/nav/dagpenger/mellomlagring/TestApplication.kt
+++ b/src/test/kotlin/no/nav/dagpenger/mellomlagring/TestApplication.kt
@@ -18,21 +18,23 @@ internal object TestApplication {
     }
 
     internal val tokenXToken: String by lazy {
-        mockOAuth2Server.issueToken(
-            issuerId = Config.TokenX.name,
-            audience = Config.TokenX.audience,
-            claims =
-                mapOf<String, Any>(
-                    "pid" to this.DEFAULT_DUMMY_FODSELNUMMER,
-                ),
-        ).serialize()
+        mockOAuth2Server
+            .issueToken(
+                issuerId = Config.TokenX.name,
+                audience = Config.TokenX.audience,
+                claims =
+                    mapOf<String, Any>(
+                        "pid" to this.DEFAULT_DUMMY_FODSELNUMMER,
+                    ),
+            ).serialize()
     }
 
     internal val azureAd: String by lazy {
-        mockOAuth2Server.issueToken(
-            issuerId = Config.AzureAd.name,
-            audience = Config.AzureAd.audience,
-        ).serialize()
+        mockOAuth2Server
+            .issueToken(
+                issuerId = Config.AzureAd.name,
+                audience = Config.AzureAd.audience,
+            ).serialize()
     }
 
     internal fun withMockAuthServerAndTestApplication(

--- a/src/test/kotlin/no/nav/dagpenger/mellomlagring/av/AntiVirusTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/mellomlagring/av/AntiVirusTest.kt
@@ -49,9 +49,13 @@ internal class AntiVirusTest {
 
             registry.scrape().also { snapshots ->
                 val teller =
-                    snapshots.find { it.metadata.name == "dp_mellomlagring_clamav_client_status" }
+                    snapshots
+                        .find { it.metadata.name == "dp_mellomlagring_clamav_client_status" }
                         .shouldNotBeNull() as CounterSnapshot
-                teller.dataPoints.first().labels.get("status") shouldBe "200"
+                teller.dataPoints
+                    .first()
+                    .labels
+                    .get("status") shouldBe "200"
                 teller.dataPoints.first().value shouldBe 1.0
             }
         }

--- a/src/test/kotlin/no/nav/dagpenger/mellomlagring/lagring/KryptertStoreTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/mellomlagring/lagring/KryptertStoreTest.kt
@@ -39,31 +39,33 @@ internal class KryptertStoreTest {
         val kryptertStore = KryptertStore(fnr = testFnr, store = s3store, aead = Crypto.aead)
 
         val lagretHubbaUrn = "urn:vedlegg:id/hubba"
-        kryptertStore.lagre(
-            Klump(
-                innhold = "hubba".toByteArray(),
-                klumpInfo =
-                    KlumpInfo(
-                        objektNavn = lagretHubbaUrn,
-                        originalFilnavn = "hubbaOriginalFilnavn",
-                        storrelse = 6,
-                        eier = testFnr,
-                    ),
-            ),
-        ).isSuccess shouldBe true
+        kryptertStore
+            .lagre(
+                Klump(
+                    innhold = "hubba".toByteArray(),
+                    klumpInfo =
+                        KlumpInfo(
+                            objektNavn = lagretHubbaUrn,
+                            originalFilnavn = "hubbaOriginalFilnavn",
+                            storrelse = 6,
+                            eier = testFnr,
+                        ),
+                ),
+            ).isSuccess shouldBe true
 
-        kryptertStore.lagre(
-            Klump(
-                innhold = "hubba bubba".toByteArray(),
-                klumpInfo =
-                    KlumpInfo(
-                        objektNavn = "urn:vedlegg:id/bubba",
-                        originalFilnavn = "hubbaOriginalFilnavn",
-                        storrelse = 6,
-                        eier = testFnr,
-                    ),
-            ),
-        ).isSuccess shouldBe true
+        kryptertStore
+            .lagre(
+                Klump(
+                    innhold = "hubba bubba".toByteArray(),
+                    klumpInfo =
+                        KlumpInfo(
+                            objektNavn = "urn:vedlegg:id/bubba",
+                            originalFilnavn = "hubbaOriginalFilnavn",
+                            storrelse = 6,
+                            eier = testFnr,
+                        ),
+                ),
+            ).isSuccess shouldBe true
 
         s3store.hent(lagretHubbaUrn).getOrThrow().also {
             require(it != null)
@@ -105,18 +107,19 @@ internal class KryptertStoreTest {
             )
         KryptertStore(fnr = testFnr, store = s3store, aead = Crypto.aead).also {
             require(
-                it.lagre(
-                    Klump(
-                        innhold = "hubba".toByteArray(),
-                        klumpInfo =
-                            KlumpInfo(
-                                objektNavn = "urn:vedlegg:id/hubba",
-                                originalFilnavn = "hubba",
-                                storrelse = 0,
-                                eier = testFnr,
-                            ),
-                    ),
-                ).isSuccess,
+                it
+                    .lagre(
+                        Klump(
+                            innhold = "hubba".toByteArray(),
+                            klumpInfo =
+                                KlumpInfo(
+                                    objektNavn = "urn:vedlegg:id/hubba",
+                                    originalFilnavn = "hubba",
+                                    storrelse = 0,
+                                    eier = testFnr,
+                                ),
+                        ),
+                    ).isSuccess,
             )
         }
 

--- a/src/test/kotlin/no/nav/dagpenger/mellomlagring/lagring/S3StoreTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/mellomlagring/lagring/S3StoreTest.kt
@@ -70,33 +70,35 @@ internal class S3StoreTest {
                     ),
             )
 
-        store.lagre(
-            Klump(
-                innhold = "hubba".toByteArray(),
-                klumpInfo =
-                    KlumpInfo(
-                        objektNavn = "urn:vedlegg:id/hubba",
-                        originalFilnavn = "hubba",
-                        storrelse = 10,
-                        eier = "hubba eier",
-                        tidspunkt = today,
-                    ),
-            ),
-        ).isSuccess shouldBe true
+        store
+            .lagre(
+                Klump(
+                    innhold = "hubba".toByteArray(),
+                    klumpInfo =
+                        KlumpInfo(
+                            objektNavn = "urn:vedlegg:id/hubba",
+                            originalFilnavn = "hubba",
+                            storrelse = 10,
+                            eier = "hubba eier",
+                            tidspunkt = today,
+                        ),
+                ),
+            ).isSuccess shouldBe true
 
-        store.lagre(
-            Klump(
-                innhold = "bubba".toByteArray(),
-                klumpInfo =
-                    KlumpInfo(
-                        objektNavn = "urn:vedlegg:id/bubba",
-                        originalFilnavn = "bubba",
-                        storrelse = 0,
-                        eier = null,
-                        tidspunkt = today,
-                    ),
-            ),
-        ).isSuccess shouldBe true
+        store
+            .lagre(
+                Klump(
+                    innhold = "bubba".toByteArray(),
+                    klumpInfo =
+                        KlumpInfo(
+                            objektNavn = "urn:vedlegg:id/bubba",
+                            originalFilnavn = "bubba",
+                            storrelse = 0,
+                            eier = null,
+                            tidspunkt = today,
+                        ),
+                ),
+            ).isSuccess shouldBe true
 
         val orThrow = store.listKlumpInfo("urn:vedlegg:id").getOrThrow()
         orThrow shouldContainExactlyInAnyOrder

--- a/src/test/kotlin/no/nav/dagpenger/mellomlagring/pdf/ImageProcessorTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/mellomlagring/pdf/ImageProcessorTest.kt
@@ -34,26 +34,27 @@ internal class ImageProcessorTest {
     @Test
     fun `slår sammen pdfer`() {
         shouldNotThrowAny {
-            ImageProcessor.mergePdf("/fisk1.jpg".fileAsByteArray().tilPdf(), "/fisk2.jpg".fileAsByteArray().tilPdf())
+            ImageProcessor
+                .mergePdf("/fisk1.jpg".fileAsByteArray().tilPdf(), "/fisk2.jpg".fileAsByteArray().tilPdf())
                 .takeIf { skrivTilFil }
                 ?.let {
                     File("build/tmp/jpgOgJpg.pdf").writeBytes(it)
                 }
 
-            ImageProcessor.mergePdf(
-                "/Arbeidsforhold.pdf".fileAsByteArray().tilPdf(),
-                "/fisk2.jpg".fileAsByteArray().tilPdf(),
-            )
-                .takeIf { skrivTilFil }
+            ImageProcessor
+                .mergePdf(
+                    "/Arbeidsforhold.pdf".fileAsByteArray().tilPdf(),
+                    "/fisk2.jpg".fileAsByteArray().tilPdf(),
+                ).takeIf { skrivTilFil }
                 ?.let {
                     File("build/tmp/PdfOgJpg.pdf").writeBytes(it)
                 }
 
-            ImageProcessor.mergePdf(
-                "/Arbeidsforhold.pdf".fileAsByteArray().tilPdf(),
-                "/Arbeidsforhold.pdf".fileAsByteArray().tilPdf(),
-            )
-                .takeIf { skrivTilFil }
+            ImageProcessor
+                .mergePdf(
+                    "/Arbeidsforhold.pdf".fileAsByteArray().tilPdf(),
+                    "/Arbeidsforhold.pdf".fileAsByteArray().tilPdf(),
+                ).takeIf { skrivTilFil }
                 ?.let {
                     File("build/tmp/PdfOgPdf.pdf").writeBytes(it)
                 }

--- a/src/test/kotlin/no/nav/dagpenger/mellomlagring/pdf/PdfApiTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/mellomlagring/pdf/PdfApiTest.kt
@@ -40,11 +40,12 @@ internal class PdfApiTest {
     @Test
     fun `Autoriset dersom tokenX token i request`() {
         withMockAuthServerAndTestApplication({ pdfApi(mockk(relaxed = true)) }) {
-            client.post(BUNDLE_PATH) {
-                autentisert(
-                    token = tokenXToken,
-                )
-            }.status shouldNotBe HttpStatusCode.Unauthorized
+            client
+                .post(BUNDLE_PATH) {
+                    autentisert(
+                        token = tokenXToken,
+                    )
+                }.status shouldNotBe HttpStatusCode.Unauthorized
         }
     }
 
@@ -64,20 +65,22 @@ internal class PdfApiTest {
                 },
             )
         }) {
-            client.post(BUNDLE_PATH) {
-                autentisert(token = tokenXToken)
-                header(HttpHeaders.ContentType, "application/json")
-                setBody(bundleBody)
-            }.let { response ->
-                response.status shouldBe HttpStatusCode.Created
-                response.contentType().toString() shouldBe "application/json; charset=UTF-8"
-                //language=JSON
-                response.bodyAsText() shouldBe """{"filnavn":"bundle.pdf","urn":"urn:vedlegg:objektnavn","filsti":"objektnavn","storrelse":0,"tidspunkt":"${
-                    now.format(
-                        DateTimeFormatter.ISO_OFFSET_DATE_TIME,
-                    )
-                }"}"""
-            }
+            client
+                .post(BUNDLE_PATH) {
+                    autentisert(token = tokenXToken)
+                    header(HttpHeaders.ContentType, "application/json")
+                    setBody(bundleBody)
+                }.let { response ->
+                    response.status shouldBe HttpStatusCode.Created
+                    response.contentType().toString() shouldBe "application/json; charset=UTF-8"
+                    //language=JSON
+                    response.bodyAsText() shouldBe
+                        """{"filnavn":"bundle.pdf","urn":"urn:vedlegg:objektnavn","filsti":"objektnavn","storrelse":0,"tidspunkt":"${
+                            now.format(
+                                DateTimeFormatter.ISO_OFFSET_DATE_TIME,
+                            )
+                        }"}"""
+                }
         }
     }
 

--- a/src/test/kotlin/no/nav/dagpenger/mellomlagring/test/IOUtils.kt
+++ b/src/test/kotlin/no/nav/dagpenger/mellomlagring/test/IOUtils.kt
@@ -3,9 +3,8 @@ package no.nav.dagpenger.mellomlagring.test
 import java.io.FileNotFoundException
 import java.io.InputStream
 
-internal fun String.fileAsInputStream(): InputStream {
-    return object {}.javaClass.getResource(this)?.openStream()
+internal fun String.fileAsInputStream(): InputStream =
+    object {}.javaClass.getResource(this)?.openStream()
         ?: throw FileNotFoundException()
-}
 
 internal fun String.fileAsByteArray(): ByteArray = this.fileAsInputStream().use { it.readAllBytes() }

--- a/src/test/kotlin/no/nav/dagpenger/mellomlagring/vedlegg/MediatorTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/mellomlagring/vedlegg/MediatorTest.kt
@@ -59,7 +59,8 @@ class MediatorTest {
                 klumpinfo.objektNavn shouldBe "id/f9ece50c-e833-43c6-996e-aa70ddbc9870"
                 klumpinfo.originalFilnavn shouldBe "hubba"
             }
-            mediator.lagre("id", "hubba bubba", "hubba bubba".toByteArray(), "application/octet-stream", "eier")
+            mediator
+                .lagre("id", "hubba bubba", "hubba bubba".toByteArray(), "application/octet-stream", "eier")
                 .let { klumpinfo ->
                     klumpinfo.objektNavn shouldBe "id/7170c6c2-17ca-11ed-861d-0242ac120002"
                     klumpinfo.originalFilnavn shouldBe "hubba bubba"


### PR DESCRIPTION
- **Bump no.nav.dagpenger:image-utils (#278)**
- **Bump no.nav.dagpenger:dp-version-catalog (#280)**
- **Bump io.micrometer:micrometer-registry-prometheus from 1.13.6 to 1.14.1 (#279)**
- **Bump no.nav.dagpenger:dp-version-catalog (#281)**
- **Bump no.nav.dagpenger:dp-version-catalog (#283)**
- **Bump no.nav.dagpenger:dp-version-catalog (#285)**
- **Bump com.google.crypto.tink:tink from 1.15.0 to 1.16.0 (#286)**
- **Bump no.nav.dagpenger:dp-version-catalog (#287)**
- **Bump no.nav.dagpenger:dp-version-catalog (#288)**
- **Bump io.micrometer:micrometer-registry-prometheus from 1.14.1 to 1.14.3 (#289)**
- **Bump no.nav.dagpenger:dp-version-catalog (#290)**
- **Bump dependabot/fetch-metadata from 2.2.0 to 2.3.0 (#292)**
- **Bump no.nav.dagpenger:dp-version-catalog (#293)**
- **Bump com.gradleup.shadow from 8.3.5 to 8.3.6 (#294)**
- **Bump io.micrometer:micrometer-registry-prometheus from 1.14.3 to 1.14.4 (#295)**
- **Bump no.nav.dagpenger:dp-version-catalog (#298)**
- **Bump no.nav.dagpenger:dp-version-catalog (#299)**
- **Bump no.nav.dagpenger:dp-version-catalog (#300)**
- **Bump no.nav.dagpenger:dp-version-catalog (#301)**
- **Bump no.nav.dagpenger:image-utils**
- **Bump net.logstash.logback:logstash-logback-encoder from 7.4 to 8.0**
- **Bump io.kubernetes:client-java from 21.0.2 to 23.0.0-legacy**
- **Fikse småting etter dependcies oppgradering**
- **Bruke distroless image**
- **Deply branch dev**
- **Ikke bruk deprecated medtode**
- **Ikke bruk deprecated medtode**
- **Revert "Deply branch dev"**
